### PR TITLE
Populate more packet info fields

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,7 @@
 Wireshark-MQTT
 ===========================
 
-MQTT dissetor for Wireshark was developed for debugging
+MQTT dissector for Wireshark was developed for debugging
 libemqtt (https://github.com/menudoproblema/libemqtt)
 
 

--- a/mqtt.lua
+++ b/mqtt.lua
@@ -208,8 +208,9 @@ do
 			while(offset < buffer:len()) do
 				local qos = buffer(offset, 1)
 				offset = offset + 1
-				payload_subtree:add(f.subscribe_qos, qos)
+				payload_subtree:add(f.suback_qos, qos)
 			end
+
 		else
 			if((buffer:len()-offset) > 0) then
 				local payload_subtree = subtree:add("Payload", nil)

--- a/mqtt.lua
+++ b/mqtt.lua
@@ -52,6 +52,9 @@ do
 	f.subscribe_message_id = ProtoField.uint16("mqtt.subscribe.message_id", "Message ID")
 	f.subscribe_topic = ProtoField.string("mqtt.subscribe.topic", "Topic")
 	f.subscribe_qos = ProtoField.uint8("mqtt.subscribe.qos", "QoS")
+	
+	-- SubAck
+	f.suback_qos = ProtoField.uint8("mqtt.suback.qos", "QoS")
 
 	--
 	f.payload_data = ProtoField.bytes("mqtt.payload", "Payload Data")
@@ -194,6 +197,19 @@ do
 				payload_subtree:add(f.subscribe_qos, qos)
 			end
 
+		elseif(msgindex == 9) then -- SUBACK
+			local varheader_subtree = subtree:add("Variable Header", nil)
+
+			local message_id = buffer(offset, 2)
+			offset = offset + 2
+			varheader_subtree:add(f.subscribe_message_id, message_id)
+
+			local payload_subtree = subtree:add("Payload", nil)
+			while(offset < buffer:len()) do
+				local qos = buffer(offset, 1)
+				offset = offset + 1
+				payload_subtree:add(f.subscribe_qos, qos)
+			end
 		else
 			if((buffer:len()-offset) > 0) then
 				local payload_subtree = subtree:add("Payload", nil)

--- a/mqtt.lua
+++ b/mqtt.lua
@@ -58,7 +58,7 @@ do
 
 	-- The dissector function
 	function MQTTPROTO.dissector(buffer, pinfo, tree)
-	    pinfo.cols.protocol = "MQTT"
+		pinfo.cols.protocol = "MQTT"
 		local msg_types = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }
 		msg_types[1] = "CONNECT"
 		msg_types[2] = "CONNACK"

--- a/mqtt.lua
+++ b/mqtt.lua
@@ -58,6 +58,7 @@ do
 
 	-- The dissector function
 	function MQTTPROTO.dissector(buffer, pinfo, tree)
+	    pinfo.cols.protocol = "MQTT"
 		local msg_types = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14 }
 		msg_types[1] = "CONNECT"
 		msg_types[2] = "CONNACK"
@@ -83,6 +84,7 @@ do
 		local fixheader_subtree = subtree:add("Fixed Header", nil)
 
 		subtree:append_text(", Message Type: " .. msg_types[msgindex])
+		pinfo.cols.info:set(msg_types[msgindex])
 
 		fixheader_subtree:add(f.message_type, msgtype)
 		fixheader_subtree:add(f.dup, msgtype)
@@ -191,7 +193,6 @@ do
 				payload_subtree:add(f.subscribe_topic, topic)
 				payload_subtree:add(f.subscribe_qos, qos)
 			end
-
 
 		else
 			if((buffer:len()-offset) > 0) then


### PR DESCRIPTION
It is desirable to have the "protocol" and "info" fields of the packet_info properly populated. With these changes, then (for instance) tshark output looks like this:

```
 29   6.139663    127.0.0.1 60326 127.0.0.1    1883 MQTT CONNECT
 31   6.140923    127.0.0.1 1883 127.0.0.1    60326 MQTT CONNACK
 33   6.146678    127.0.0.1 60326 127.0.0.1    1883 MQTT PUBLISH
 35   6.147815    127.0.0.1 1883 127.0.0.1    60326 MQTT PUBREC
 37   6.148801    127.0.0.1 60326 127.0.0.1    1883 MQTT PUBREL
 39   6.150329    127.0.0.1 1883 127.0.0.1    60319 MQTT PUBLISH
 41   6.150631    127.0.0.1 1883 127.0.0.1    60326 MQTT PUBCOMP
 43   6.151260    127.0.0.1 60319 127.0.0.1    1883 MQTT PUBREC
 45   6.151664    127.0.0.1 1883 127.0.0.1    60319 MQTT PUBREL
 47   6.153478    127.0.0.1 60326 127.0.0.1    1883 MQTT DISCONNECT
 49   6.155721    127.0.0.1 60319 127.0.0.1    1883 MQTT PUBCOMP
```

Also, the display filter "mqtt" can be used.
