### PR TITLE
fixed syntax error(missing 'then')

### DIFF
--- a/mqtt.lua
+++ b/mqtt.lua
@@ -214,7 +214,7 @@ do
 				offset = offset + 1
 
 				payload_subtree:add(f.subscribe_topic, topic)
-				if(msgindex == 8) -- QoS byte only for subscription
+				if(msgindex == 8) then -- QoS byte only for subscription
 					payload_subtree:add(f.subscribe_qos, qos)
 				end
 			end


### PR DESCRIPTION
Syntax error occurred in my environment(below).
- ERROR
  Lua: syntax error during precompilation of `/Users/***/.wireshark/plugins/mqtt.lua':
- Environment
  Version 1.10.8 (v1.10.8-2-g52a5244 from master-1.10)

Compiled (64-bit) with GTK+ 2.24.17, with Cairo 1.10.2, with Pango 1.30.1, with
GLib 2.36.0, with libpcap, with libz 1.2.3, without POSIX capabilities, without
libnl, with SMI 0.4.8, without c-ares, without ADNS, with Lua 5.1, without
Python, with GnuTLS 2.12.19, with Gcrypt 1.5.0, with MIT Kerberos, with GeoIP,
with PortAudio V19-devel (built Jul 16 2013 19:05:52), with AirPcap.

Running on Mac OS X 10.8.5, build 12F45 (Darwin 12.5.0), with locale sjis.UTF-8,
with libpcap version 1.1.1, with libz 1.2.5, GnuTLS 2.12.19, Gcrypt 1.5.0,
without AirPcap.
       Intel(R) Core(TM) i7-3520M CPU @ 2.90GHz

Built using llvm-gcc 4.2.1 (Based on Apple Inc. build 5658) (LLVM build
2336.9.00).
